### PR TITLE
Bumped package versions

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -265,19 +265,19 @@
         },
         "pjisp-diff": {
             "hashes": [
-                "sha256:00bdede7f984cdc4a2599f0a453196b5d4a71392cbba92449b9c8f4c415d5f52",
-                "sha256:e3ed64bc9f65aa193a3301efc427bbdc475395b3882a0069546be7baf877350b"
+                "sha256:31c168f9c6a0c7eaf25dd87148823a65131fbd691b7f0d46001e90e4942800ae",
+                "sha256:78c55bf8f1a9130d7d5a69b9ee617f0efefddd0cbfbb97aa872a4ba2c7a954a8"
             ],
             "index": "pypi",
-            "version": "==0.1.10"
+            "version": "==0.1.11"
         },
         "pjisp-template-name": {
             "hashes": [
-                "sha256:3b1f49a964b10a68ebf10ac48430a95c000b2cc2be2e91d3aa306d757b320306",
-                "sha256:71c5fc8b6c3ba86894ba81f38a454b7ca50847a6754b510335d0ca051ddcb05a"
+                "sha256:4ff54819f8909392ecfc1f1e92fc9330eacfba00369667b0efec974ceeef46ea",
+                "sha256:b92037452d3100ccdbdfa9b5ddd4ae72806a130b57494020b93f0fa35041aaf6"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "version": "==0.2.3"
         },
         "pycparser": {
             "hashes": [


### PR DESCRIPTION
Bumped pjisp-diff and pjisp-template-name package versions to be compatible with the sample-test repository